### PR TITLE
Stop orchestration when GenerateReply returns a bad request, and show the error message in toaster

### DIFF
--- a/ChatRoom/ChatRoom.Client/ChatRoom.Client.csproj
+++ b/ChatRoom/ChatRoom.Client/ChatRoom.Client.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="ChatRoom.OpenAI.Tests" />
     <InternalsVisibleTo Include="ChatRoom.Client.Tests" />
+    <InternalsVisibleTo Include="ChatRoom.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/ChatRoom/ChatRoom.Common/Controller/ChatRoomClientController.cs
+++ b/ChatRoom/ChatRoom.Common/Controller/ChatRoomClientController.cs
@@ -278,8 +278,16 @@ internal class ChatRoomClientController : Controller
         var chatMsgs = request.ChatMsgs;
         var candidates = request.Candidates;
 
-        var reply = await _chatPlatformClient.GenerateNextReply(channelName, candidates, chatMsgs, request.Orchestrator);
-        return new OkObjectResult(new GenerateNextReplyResponse(reply));
+        try
+        {
+            var reply = await _chatPlatformClient.GenerateNextReply(channelName, candidates, chatMsgs, request.Orchestrator);
+            return new OkObjectResult(new GenerateNextReplyResponse(reply));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error generating next reply");
+            return new BadRequestObjectResult(ex.Message);
+        }
     }
 
     [HttpGet]

--- a/ChatRoom/ChatRoom.Common/Orleans/ChannelGrain.cs
+++ b/ChatRoom/ChatRoom.Common/Orleans/ChannelGrain.cs
@@ -236,16 +236,25 @@ internal class ChannelGrain : Grain, IChannelGrain
             return null;
         }
 
-        var reply = await nextSpeakerObserver.GenerateReplyAsync(nextSpeaker, msgs, channelInfo);
-
-        if (reply is not null)
+        try
         {
-            _logger.LogInformation("Generated reply: {Reply}", reply.GetContent());
+            var reply = await nextSpeakerObserver.GenerateReplyAsync(nextSpeaker, msgs, channelInfo);
 
-            await this.SendMessage(reply);
+            if (reply is not null)
+            {
+                _logger.LogInformation("Generated reply: {Reply}", reply.GetContent());
+
+                await this.SendMessage(reply);
+            }
+
+            return reply;
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error generating reply");
 
-        return reply;
+            throw;
+        }
     }
 
     public Task AddOrchestratorToChannel(string name, IOrchestratorObserver orchestrator)

--- a/chatroom-ui/chatroom-client/core/ApiError.ts
+++ b/chatroom-ui/chatroom-client/core/ApiError.ts
@@ -7,6 +7,7 @@ export class ApiError extends Error {
 	public readonly statusText: string;
 	public readonly body: unknown;
 	public readonly request: ApiRequestOptions;
+	public readonly response: ApiResult;
 
 	constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
 		super(message);
@@ -17,5 +18,6 @@ export class ApiError extends Error {
 		this.statusText = response.statusText;
 		this.body = response.body;
 		this.request = request;
+		this.response = response;
 	}
 }

--- a/test/ChatRoom.Client.Tests/ChatRoom.Client.Tests.csproj
+++ b/test/ChatRoom.Client.Tests/ChatRoom.Client.Tests.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\..\ChatRoom\ChatRoom.Client\ChatRoom.Client.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ChatRoom.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/test/ChatRoom.Client.Tests/EmptyChatRoomClientFixture.cs
+++ b/test/ChatRoom.Client.Tests/EmptyChatRoomClientFixture.cs
@@ -13,13 +13,14 @@ namespace ChatRoom.Client.Tests;
 public abstract class ChatRoomClientFixture : IDisposable
 {
     private readonly Task _start;
+    private readonly ChatRoomClientConfiguration _configuration;
     public ChatRoomClientFixture(string templateName)
     {
         // called once before every test
         var configurationPath = Path.Combine("template", "chatroom", $"{templateName}.json"); // "template/chatroom/chatroom.json
-        var configuration = JsonSerializer.Deserialize<ChatRoomClientConfiguration>(File.ReadAllText(configurationPath)) ?? throw new InvalidOperationException("Failed to load configuration file.");
+        this._configuration = JsonSerializer.Deserialize<ChatRoomClientConfiguration>(File.ReadAllText(configurationPath)) ?? throw new InvalidOperationException("Failed to load configuration file.");
         this.Command = new ChatRoomClientCommand();
-        this._start = this.Command.ExecuteAsync(configuration);
+        this._start = this.Command.ExecuteAsync(this._configuration);
 
         var timeout = Task.Delay(10000);
         var deployTask = this.Command.DeployAsync();
@@ -30,6 +31,8 @@ public abstract class ChatRoomClientFixture : IDisposable
             throw new TimeoutException("Failed to deploy the client in time.");
         }
     }
+
+    internal ChatRoomClientConfiguration Configuration => _configuration;
 
     internal ChatRoomClientCommand Command { get; private set; }
 

--- a/test/ChatRoom.Tests/Program.cs
+++ b/test/ChatRoom.Tests/Program.cs
@@ -6,6 +6,9 @@ using ChatRoom.OpenAI.Tests;
 using ChatRoom.Powershell.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using ChatRoom.SDK;
+using Moq;
+using AutoGen.Core;
 
 using var defaultClientFixture = new EmptyChatRoomClientFixture();
 using var openaiFixture = new OpenAIAgentsFixture();
@@ -13,6 +16,7 @@ using var bing = new WebSearchFixture();
 using var githubFixture = new GithubAgentsFixture();
 using var psFixture = new PowershellAgentsFixture();
 using var host = Host.CreateDefaultBuilder()
+    .UseChatRoomClient(defaultClientFixture.Configuration.RoomConfig.Room, port: defaultClientFixture.Configuration.RoomConfig.Port)
     .Build();
 
 var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
@@ -23,4 +27,23 @@ applicationLifetime.ApplicationStopping.Register(() =>
 });
 
 await host.StartAsync();
+
+var client = host.Services.GetRequiredService<ChatPlatformClient>();
+
+var throwExceptionAgent = Mock.Of<IAgent>();
+Mock.Get(throwExceptionAgent)
+            .Setup(a => a.GenerateReplyAsync(It.IsAny<IEnumerable<IMessage>>(), It.IsAny<GenerateReplyOptions>(), It.IsAny<CancellationToken>()))
+            .Throws(() =>
+            {
+                Task.Delay(35 * 1000).Wait();
+
+                return new Exception("Test exception");
+            });
+
+Mock.Get(throwExceptionAgent)
+    .Setup(a => a.Name)
+    .Returns(nameof(throwExceptionAgent));
+
+await client.RegisterAutoGenAgentAsync(throwExceptionAgent);
+
 await host.WaitForShutdownAsync();


### PR DESCRIPTION
#147 