### PR TITLE
Update next and add one-click build via MSBuild

### DIFF
--- a/ChatRoom/ChatRoom.StaticWebUI/ChatRoom.StaticWebUI.csproj
+++ b/ChatRoom/ChatRoom.StaticWebUI/ChatRoom.StaticWebUI.csproj
@@ -24,16 +24,28 @@
     </Content>
   </ItemGroup>
 
-  <!-- Custom target to check if wwwroot exists -->
-  <Target Name="CheckWwwrootExists" BeforeTargets="PrepareForRun">
+  <!-- Custom target to check if wwwroot exists and build chatroom-ui if it doesn't -->
+  <Target Name="CheckAndBuildWwwroot" BeforeTargets="PrepareForRun">
     <!-- Check if the wwwroot directory exists -->
     <PropertyGroup>
       <WwwrootExists Condition="Exists('$(RepoRoot)\chatroom-ui\out\index.html')">true</WwwrootExists>
     </PropertyGroup>
 
-    <!-- Optionally, do something based on the existence of wwwroot -->
-    <Message Text="wwwroot doesn't exist. Have you built the chatroom-ui project?" Condition="'$(WwwrootExists)' == 'false'" />
-    <Error Text="The wwwroot directory does not exist. Please build chatroom-ui project by running `npm run build` under their root. For more information on how to build chatroom-ui, please refer to https://github.com/LittleLittleCloud/Agent-ChatRoom/tree/main/chatroom-ui" Condition="'$(WwwrootExists)' == 'false'" />
+    <!-- If wwwroot doesn't exist, run: npm install && npm run build -->   
+    <!-- Run npm install if wwwroot doesn't exist -->
+    <Exec Command="npm install" Condition="'$(WwwrootExists)' == 'false'" WorkingDirectory="$(RepoRoot)\chatroom-ui" />   
+    <!-- Run npm run build after npm install -->
+    <Exec Command="npm run build" Condition="'$(WwwrootExists)' == 'false'" WorkingDirectory="$(RepoRoot)\chatroom-ui" />
+    <!-- Optionally, display message after build -->
+    <Message Text="Running 'npm run build' to generate wwwroot as it doesn't exist." Condition="'$(WwwrootExists)' == 'false'" />
+
+    <!-- After the build, check again if wwwroot exists -->
+    <PropertyGroup>
+      <WwwrootExists Condition="Exists('$(RepoRoot)\chatroom-ui\out\index.html')">true</WwwrootExists>
+    </PropertyGroup>
+
+    <!-- If wwwroot still doesn't exist after the build, show an error -->
+    <Error Text="The wwwroot directory still does not exist after running 'npm run build'. Please check the chatroom-ui build process." Condition="'$(WwwrootExists)' == 'false'" />
   </Target>
 
 </Project>

--- a/chatroom-ui/package-lock.json
+++ b/chatroom-ui/package-lock.json
@@ -29,7 +29,7 @@
         "emoji-mart": "^5.6.0",
         "framer-motion": "^11.2.10",
         "lucide-react": "^0.390.0",
-        "next": "14.2.3",
+        "next": "^14.2.15",
         "next-themes": "^0.3.0",
         "openapi-typescript-codegen": "^0.29.0",
         "react": "18.2.0",
@@ -345,9 +345,9 @@
       "license": "MIT"
     },
     "node_modules/@next/env": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
+      "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -361,9 +361,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
-      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
+      "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
       "cpu": [
         "arm64"
       ],
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
+      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
       "cpu": [
         "x64"
       ],
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
+      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
       "cpu": [
         "arm64"
       ],
@@ -409,9 +409,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
+      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
       "cpu": [
         "arm64"
       ],
@@ -425,9 +425,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
-      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
+      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
       "cpu": [
         "x64"
       ],
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
-      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
+      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
       "cpu": [
         "x64"
       ],
@@ -457,9 +457,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
+      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
       "cpu": [
         "arm64"
       ],
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
+      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
       "cpu": [
         "ia32"
       ],
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
+      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
       "cpu": [
         "x64"
       ],
@@ -2836,9 +2836,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001632",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz",
-      "integrity": "sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==",
+      "version": "1.0.30001669",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
+      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
       "funding": [
         {
           "type": "opencollective",
@@ -6286,12 +6286,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
-      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
+      "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.3",
+        "@next/env": "14.2.15",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -6306,15 +6306,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.3",
-        "@next/swc-darwin-x64": "14.2.3",
-        "@next/swc-linux-arm64-gnu": "14.2.3",
-        "@next/swc-linux-arm64-musl": "14.2.3",
-        "@next/swc-linux-x64-gnu": "14.2.3",
-        "@next/swc-linux-x64-musl": "14.2.3",
-        "@next/swc-win32-arm64-msvc": "14.2.3",
-        "@next/swc-win32-ia32-msvc": "14.2.3",
-        "@next/swc-win32-x64-msvc": "14.2.3"
+        "@next/swc-darwin-arm64": "14.2.15",
+        "@next/swc-darwin-x64": "14.2.15",
+        "@next/swc-linux-arm64-gnu": "14.2.15",
+        "@next/swc-linux-arm64-musl": "14.2.15",
+        "@next/swc-linux-x64-gnu": "14.2.15",
+        "@next/swc-linux-x64-musl": "14.2.15",
+        "@next/swc-win32-arm64-msvc": "14.2.15",
+        "@next/swc-win32-ia32-msvc": "14.2.15",
+        "@next/swc-win32-x64-msvc": "14.2.15"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/chatroom-ui/package.json
+++ b/chatroom-ui/package.json
@@ -31,7 +31,7 @@
     "emoji-mart": "^5.6.0",
     "framer-motion": "^11.2.10",
     "lucide-react": "^0.390.0",
-    "next": "14.2.3",
+    "next": "^14.2.15",
     "next-themes": "^0.3.0",
     "openapi-typescript-codegen": "^0.29.0",
     "react": "18.2.0",


### PR DESCRIPTION
**Problem Description**

MSBuild solution presently forces to run `npm install` and `npm run build` manually. Simplify the build process to spawn `npm install && npm run build` from the main MSBuild in case if directory hasn't been built yet. Note that this does not rebuild if the static pages have already been built. Ideally the clean might be able to clean the static pages as well, then rebuild will actually rebuild all.

Also updated `next` to latest.